### PR TITLE
Feature/waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -98,7 +98,7 @@ class WaypointUpdater(object):
     def get_position(self, obj):
         """ Returns the position of a 'PoseStamped' or 'Waypoint' object
 
-            Args:
+            Arguments:
               obj -- 'PoseStamped' or 'Waypoint' object
 
             Return:
@@ -108,12 +108,12 @@ class WaypointUpdater(object):
             return obj.pose.position
         elif (type(obj) is Waypoint):
             return obj.pose.pose.position
-        assert 0, "Invalid object type (expected: PoseStamped, Waypoint)"
+        assert 0, "Invalid object type (expected: 'PoseStamped', 'Waypoint')"
 
     def get_orientation(self, obj):
         """ Returns the orientation of a 'PoseStamped' or 'Waypoint' object
 
-            Args:
+            Arguments:
               obj -- 'PoseStamped' or 'Waypoint' object
 
             Return:
@@ -123,7 +123,7 @@ class WaypointUpdater(object):
             return obj.pose.orientation
         elif (type(obj) is Waypoint):
             return obj.pose.pose.orientation
-        assert 0, "Invalid object type (expected: PoseStamped, Waypoint)"
+        assert 0, "Invalid object type (expected: 'PoseStamped', 'Waypoint')"
 
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
@@ -131,13 +131,25 @@ class WaypointUpdater(object):
     def set_waypoint_velocity(self, waypoints, waypoint, velocity):
         waypoints[waypoint].twist.twist.linear.x = velocity
 
-    def distance(self, waypoints, wp1, wp2):
+    def distance(self, p1, p2):
+        """ Calculate the Euclidean distance between two positions ('p1', 'p2')
+
+            Arguments:
+              p1 -- Position 1 (x, y, z)
+              p2 -- Position 2 (x, y, z)
+
+            Return:
+              Return the (Euclidean) distance between 'p1' and 'p2'
+        """
+        return math.sqrt((p1.x - p2.x)**2 
+                         + (p1.y - p2.y)**2 
+                         + (p1.z - p2.z)**2)
+
+    def distance_path(self, waypoints, wp1, wp2):
         dist = 0
-        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + 
-                                    (a.z-b.z)**2)
         for i in range(wp1, wp2+1):
-            dist += dl(waypoints[wp1].pose.pose.position, 
-                       waypoints[i].pose.pose.position)
+            dist += self.distance(waypoints[wp1].pose.pose.position, 
+                                  waypoints[i].pose.pose.position)
             wp1 = i
         return dist
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -110,6 +110,21 @@ class WaypointUpdater(object):
             return obj.pose.pose.position
         assert 0, "Invalid object type (expected: PoseStamped, Waypoint)"
 
+    def get_orientation(self, obj):
+        """ Returns the orientation of a 'PoseStamped' or 'Waypoint' object
+
+            Args:
+              obj -- 'PoseStamped' or 'Waypoint' object
+
+            Return:
+              Orientation of 'obj'
+        """
+        if (type(obj) is PoseStamped):
+            return obj.pose.orientation
+        elif (type(obj) is Waypoint):
+            return obj.pose.pose.orientation
+        assert 0, "Invalid object type (expected: PoseStamped, Waypoint)"
+
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -80,8 +80,12 @@ class WaypointUpdater(object):
         pass
 
     def waypoints_cb(self, waypoints):
-        # TODO: Implement
-        pass
+        """ Receives a list of track waypoints and stores them internally
+            
+            Arguments:
+              waypoints -- List of track waypoints
+        """
+        self.waypoints = waypoints.waypoints
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message.

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -7,21 +7,24 @@ from styx_msgs.msg import Lane, Waypoint
 import math
 
 '''
-This node will publish waypoints from the car's current position to some `x` distance ahead.
+This node will publish waypoints from the car's current position to some `x`
+distance ahead.
 
-As mentioned in the doc, you should ideally first implement a version which does not care
-about traffic lights or obstacles.
+As mentioned in the doc, you should ideally first implement a version which
+does not care about traffic lights or obstacles.
 
-Once you have created dbw_node, you will update this node to use the status of traffic lights too.
+Once you have created dbw_node, you will update this node to use the status
+of traffic lights too.
 
-Please note that our simulator also provides the exact location of traffic lights and their
-current status in `/vehicle/traffic_lights` message. You can use this message to build this node
-as well as to verify your TL classifier.
+Please note that our simulator also provides the exact location of traffic
+lights and their current status in `/vehicle/traffic_lights` message.
+You can use this message to build this node as well as to verify your TL
+classifier.
 
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
+LOOKAHEAD_WPS = 200 # Number of waypoints we will publish.
 
 
 class WaypointUpdater(object):
@@ -31,10 +34,11 @@ class WaypointUpdater(object):
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
+        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint
 
 
-        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, 
+                                                   queue_size=1)
 
         # TODO: Add other member variables you need below
 
@@ -49,11 +53,11 @@ class WaypointUpdater(object):
         pass
 
     def traffic_cb(self, msg):
-        # TODO: Callback for /traffic_waypoint message. Implement
+        # TODO: Callback for /traffic_waypoint message.
         pass
 
     def obstacle_cb(self, msg):
-        # TODO: Callback for /obstacle_waypoint message. We will implement it later
+        # TODO: Callback for /obstacle_waypoint message.
         pass
 
     def get_waypoint_velocity(self, waypoint):
@@ -64,9 +68,11 @@ class WaypointUpdater(object):
 
     def distance(self, waypoints, wp1, wp2):
         dist = 0
-        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
+        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + 
+                                    (a.z-b.z)**2)
         for i in range(wp1, wp2+1):
-            dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
+            dist += dl(waypoints[wp1].pose.pose.position, 
+                       waypoints[i].pose.pose.position)
             wp1 = i
         return dist
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -12,18 +12,6 @@ import sys
 This node will publish waypoints from the car's current position to some `x`
 distance ahead.
 
-As mentioned in the doc, you should ideally first implement a version which
-does not care about traffic lights or obstacles.
-
-Once you have created dbw_node, you will update this node to use the status
-of traffic lights too.
-
-Please note that our simulator also provides the exact location of traffic
-lights and their current status in `/vehicle/traffic_lights` message.
-You can use this message to build this node as well as to verify your TL
-classifier.
-
-TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 # Constants

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -172,6 +172,19 @@ class WaypointUpdater(object):
     def set_waypoint_velocity(self, waypoints, waypoint, velocity):
         waypoints[waypoint].twist.twist.linear.x = velocity
 
+    def get_waypoint_string(self, wp):
+        """ Converts a waypoint to string and returns the string
+
+            Arguments:
+              wp -- Waypoint
+
+            Return:
+              Waypoint string
+        """
+        return ('%s - %s - %s' % (self.get_position_string(wp),
+                                  self.get_orientation_string(wp),
+                                  self.get_waypoint_twist_string(wp)))
+
     def distance(self, p1, p2):
         """ Calculate the Euclidean distance between two positions ('p1', 'p2')
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -110,6 +110,19 @@ class WaypointUpdater(object):
             return obj.pose.pose.position
         assert 0, "Invalid object type (expected: 'PoseStamped', 'Waypoint')"
 
+    def get_position_string(self, obj):
+        """ Returns the position of a 'PoseStamped' or 'Waypoint' object as a
+            string
+
+            Arguments:
+              obj -- 'PoseStamped' or 'Waypoint' object
+
+            Return:
+              Position of 'obj' as string
+        """
+        pos = self.get_position(obj)
+        return ('pos(%.2f, %.2f, %.2f)' % (pos.x, pos.y, pos.z))
+
     def get_orientation(self, obj):
         """ Returns the orientation of a 'PoseStamped' or 'Waypoint' object
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -75,7 +75,7 @@ class WaypointUpdater(object):
         # Start node
         rospy.spin()
 
-    def pose_cb(self, msg):
+    def pose_cb(self, pose):
         # TODO: Implement
         pass
 
@@ -184,6 +184,20 @@ class WaypointUpdater(object):
         return ('%s - %s - %s' % (self.get_position_string(wp),
                                   self.get_orientation_string(wp),
                                   self.get_waypoint_twist_string(wp)))
+
+    def get_pose_string(self, pose):
+        """ Converts a time-stamped pose to string and returns the string
+
+            Arguments:
+              ps -- Time-stamped pose
+
+            Return:
+              Time-stamped pose string
+        """
+        return ('t(%.2f s) - %s - %s' % 
+                (pose.header.stamp.to_sec() - self.start_time, 
+                 self.get_position_string(pose),
+                 self.get_orientation_string(pose)))
 
     def distance(self, p1, p2):
         """ Calculate the Euclidean distance between two positions ('p1', 'p2')

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -95,6 +95,21 @@ class WaypointUpdater(object):
         # TODO: Callback for /obstacle_waypoint message.
         pass
 
+    def get_position(self, obj):
+        """ Returns the position of a 'PoseStamped' or 'Waypoint' object
+
+            Args:
+              obj -- 'PoseStamped' or 'Waypoint' object
+
+            Return:
+              Position of 'obj'
+        """
+        if (type(obj) is PoseStamped):
+            return obj.pose.position
+        elif (type(obj) is Waypoint):
+            return obj.pose.pose.position
+        assert 0, "Invalid object type (expected: PoseStamped, Waypoint)"
+
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -138,6 +138,20 @@ class WaypointUpdater(object):
             return obj.pose.pose.orientation
         assert 0, "Invalid object type (expected: 'PoseStamped', 'Waypoint')"
 
+    def get_orientation_string(self, obj):
+        """ Returns the orientation of a 'PoseStamped' or 'Waypoint' object
+            as a string
+
+            Arguments:
+              obj -- 'PoseStamped' or 'Waypoint' object
+
+            Return:
+              Orientation of 'obj' as a string
+        """
+        orient = self.get_orientation(obj)
+        return ('orient(%.2f, %.2f, %.2f, %.2f)' % 
+                (orient.x, orient.y, orient.z, orient.w))
+
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -152,6 +152,20 @@ class WaypointUpdater(object):
         return ('orient(%.2f, %.2f, %.2f, %.2f)' % 
                 (orient.x, orient.y, orient.z, orient.w))
 
+    def get_waypoint_twist_string(self, wp):
+        """ Returns the twist of a waypoint as a string
+
+            Arguments:
+              wp -- Waypoint
+
+            Return:
+              Twist of waypoint as a string
+        """
+        twl = wp.twist.twist.linear
+        twa = wp.twist.twist.angular
+        return ('twist[lin(%.2f, %.2f, %.2f), ang(%.2f, %.2f, %.2f)]' %
+                (twl.x, twl.y, twl.z, twa.x, twa.y, twa.z))
+
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
 
@@ -166,7 +180,7 @@ class WaypointUpdater(object):
               p2 -- Position 2 (x, y, z)
 
             Return:
-              Return the (Euclidean) distance between 'p1' and 'p2'
+              Euclidean distance between 'p1' and 'p2'
         """
         return math.sqrt((p1.x - p2.x)**2 
                          + (p1.y - p2.y)**2 


### PR DESCRIPTION
First version of the waypoint updater:
- The selection of the waypoint in front of the car is simplified. In roughly half the cases, it may not be the point directly in front of the car, but the point after that. Given the fine granularity of the waypoints, this should not lead to problems. 
- New waypoints are only published when the vehicle moved more than MIN_UPDATE_DIST (currently: 0.01 m) (solves the latency issue on my system).
- Traffic lights and obstacles are not considered yet
- The selection of the next waypoints can be improved (based on the (known) car motion and previously selected paths)

To test:
- Start the docker container with: ./ros-start.sh
- Start ROS in styx mode: ./ros-styx.sh
- Start the Udacity Simulator
- Drive the car manually and observe the trajectory that is overlaid on the track