### PR TITLE
Feature/tl detector

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -26,19 +26,22 @@ class TLDetector(object):
         sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
         '''
-        /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
-        helps you acquire an accurate ground truth data source for the traffic light
-        classifier by sending the current color state of all traffic lights in the
-        simulator. When testing on the vehicle, the color state will not be available. You'll need to
+        /vehicle/traffic_lights provides you with the location of the traffic 
+        light in 3D map space and helps you acquire an accurate ground truth 
+        data source for the traffic light classifier by sending the current 
+        color state of all traffic lights in the simulator. When testing on the 
+        vehicle, the color state will not be available. You'll need to
         rely on the position of the light and the camera image to predict it.
         '''
-        sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
+        sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, 
+                                self.traffic_cb)
         sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)
 
         config_string = rospy.get_param("/traffic_light_config")
         self.config = yaml.load(config_string)
 
-        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
+        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', 
+                                                      Int32, queue_size=1)
 
         self.bridge = CvBridge()
         self.light_classifier = TLClassifier()
@@ -61,8 +64,9 @@ class TLDetector(object):
         self.lights = msg.lights
 
     def image_cb(self, msg):
-        """Identifies red lights in the incoming camera image and publishes the index
-            of the waypoint closest to the red light's stop line to /traffic_waypoint
+        """Identifies red lights in the incoming camera image and publishes the 
+           index of the waypoint closest to the red light's stop line to
+           /traffic_waypoint
 
         Args:
             msg (Image): image from car-mounted camera
@@ -110,7 +114,8 @@ class TLDetector(object):
             light (TrafficLight): light to classify
 
         Returns:
-            int: ID of traffic light color (specified in styx_msgs/TrafficLight)
+            int: ID of traffic light color 
+                 (specified in styx_msgs/TrafficLight)
 
         """
         if(not self.has_image):
@@ -123,17 +128,20 @@ class TLDetector(object):
         return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
-        """Finds closest visible traffic light, if one exists, and determines its
-            location and color
+        """Finds closest visible traffic light, if one exists, and determines 
+           its location and color
 
         Returns:
-            int: index of waypoint closes to the upcoming stop line for a traffic light (-1 if none exists)
-            int: ID of traffic light color (specified in styx_msgs/TrafficLight)
+            int: index of waypoint closest to the upcoming stop line for a 
+                 traffic light (-1 if none exists)
+            int: ID of traffic light color 
+                 (specified in styx_msgs/TrafficLight)
 
         """
         light = None
 
-        # List of positions that correspond to the line to stop in front of for a given intersection
+        # List of positions that correspond to the line to stop in front of for 
+        # a given intersection
         stop_line_positions = self.config['stop_line_positions']
         if(self.pose):
             car_position = self.get_closest_waypoint(self.pose.pose)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -125,6 +125,8 @@ class TLDetector(object):
     def get_light_state(self, light):
         """Determines the current color of the traffic light
 
+           (adapted from Udacity SDC-ND Programming a Real Self-Driving Car 
+            Project Walkthrough (Term 3))
         Args:
             light (TrafficLight): light to classify
 
@@ -133,14 +135,16 @@ class TLDetector(object):
                  (specified in styx_msgs/TrafficLight)
 
         """
-        if(not self.has_image):
-            self.prev_light_loc = None
-            return False
+        # TODO: Replace with call to classifier
+        return light.state
+        #if(not self.has_image):
+        #    self.prev_light_loc = None
+        #    return False
 
-        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
+        #cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
         #Get classification
-        return self.light_classifier.get_classification(cv_image)
+        #return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -150,6 +150,9 @@ class TLDetector(object):
         """Finds closest visible traffic light, if one exists, and determines 
            its location and color
 
+           (adapted from Udacity Programming a Real Self-Driving Car Project 
+            Walkthrough (Term 3))
+
         Returns:
             int: index of waypoint closest to the upcoming stop line for a 
                  traffic light (-1 if none exists)
@@ -157,18 +160,31 @@ class TLDetector(object):
                  (specified in styx_msgs/TrafficLight)
 
         """
-        light = None
+        closest_light = None
+        line_wp_idx = None
 
-        # List of positions that correspond to the line to stop in front of for 
-        # a given intersection
+        # List of positions that correspond to the line to stop in front of 
+        # for a given intersection
         stop_line_positions = self.config['stop_line_positions']
+        if(self.pose):
+            car_wp_idx = self.get_closest_waypoint(self.pose.pose.position.x,
+                                                   self.pose.pose.position.y)
 
-        #TODO find the closest visible traffic light (if one exists)
+            diff = len(self.waypoints.waypoints)
+            for i, light in enumerate(self.lights):
+                # Get stop line waypoint index
+                line = stop_line_positions[i]
+                temp_wp_idx = self.get_closest_waypoint(line[0], line[1])
+                # Find closest stop line waypoint index
+                d = temp_wp_idx - car_wp_idx
+                if d >= 0 and d < diff:
+                    diff = d
+                    closest_light = light
+                    line_wp_idx = temp_wp_idx
 
-        if light:
-            state = self.get_light_state(light)
-            return light_wp, state
-        self.waypoints = None
+        if closest_light:
+            state = self.get_light_state(closest_light)
+            return line_wp_idx, state
         return -1, TrafficLight.UNKNOWN
 
 if __name__ == '__main__':

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -2,6 +2,7 @@
 import rospy
 from std_msgs.msg import Int32
 from geometry_msgs.msg import PoseStamped, Pose
+from scipy.spatial import KDTree
 from styx_msgs.msg import TrafficLightArray, TrafficLight
 from styx_msgs.msg import Lane
 from sensor_msgs.msg import Image
@@ -52,13 +53,25 @@ class TLDetector(object):
         self.last_wp = -1
         self.state_count = 0
 
+        # Adapted from Udacity SDC-ND Programming a Real Self-Driving Car 
+        # Project Walkthrough (Term 3)
+        self.waypoint_tree = None
+
         rospy.spin()
 
     def pose_cb(self, msg):
         self.pose = msg
 
     def waypoints_cb(self, waypoints):
+        if self.waypoints:
+            return
         self.waypoints = waypoints
+
+        # Adapted from Udacity SDC-ND Programming a Real Self-Driving Car 
+        # Project Walkthrough (Term 3)
+        waypoints_2d = [[wp.pose.pose.position.x, wp.pose.pose.position.y]\
+                           for wp in waypoints.waypoints]
+        self.waypoint_tree = KDTree(waypoints_2d)
 
     def traffic_cb(self, msg):
         self.lights = msg.lights

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -107,9 +107,12 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
-    def get_closest_waypoint(self, pose):
+    def get_closest_waypoint(self, x, y):
         """Identifies the closest path waypoint to the given position
             https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
+
+           (adapted from Udacity SDC-ND Programming a Real Self-Driving Car 
+            Project Walkthrough (Term 3))
         Args:
             pose (Pose): position to match a waypoint to
 
@@ -117,8 +120,7 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        #TODO implement
-        return 0
+        return self.waypoint_tree.query([x, y], 1)[1]
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -156,8 +158,6 @@ class TLDetector(object):
         # List of positions that correspond to the line to stop in front of for 
         # a given intersection
         stop_line_positions = self.config['stop_line_positions']
-        if(self.pose):
-            car_position = self.get_closest_waypoint(self.pose.pose)
 
         #TODO find the closest visible traffic light (if one exists)
 


### PR DESCRIPTION
This is a simplified version of the traffic light detector (based on the project walkthrough) that allows testing of the waypoint updater and dbw node without camera images (based on the known traffic light states in the simulator).

It uses a fixed update rate (in comparison to the camera frequency driven approach that was used orginally).